### PR TITLE
Fix bug with teamcity API

### DIFF
--- a/teamcity/jobs/teamcity.rb
+++ b/teamcity/jobs/teamcity.rb
@@ -3,7 +3,7 @@ require 'teamcity'
 def update_builds(build_id)
   builds = []
 
-  build = TeamCity.builds(count: 1, buildType: build_id).first
+  build = TeamCity.build(id: TeamCity.builds(count: 1, buildType: build_id).first.id)
   date = DateTime.parse(build.startDate)
 
   build_info = {


### PR DESCRIPTION
The API builds method doesn't return an object that responds to startDate, so get the build ID with builds and use build method to get the object instead
