### PR TITLE
Fix to make widget red when build fails

### DIFF
--- a/teamcity/widgets/team_city/team_city.coffee
+++ b/teamcity/widgets/team_city/team_city.coffee
@@ -11,5 +11,5 @@ class Dashing.TeamCity extends Dashing.Widget
     @_checkStatus(data.items[0].state)
 
   _checkStatus: (status) ->
-    $(@node).removeClass('errored failed passed started')
+    $(@node).removeClass('ERROR FAILURE SUCCESS')
     $(@node).addClass(status)

--- a/teamcity/widgets/team_city/team_city.scss
+++ b/teamcity/widgets/team_city/team_city.scss
@@ -5,7 +5,6 @@ $value-color:              #FFF;
 $background-color:         #78A300;
 $background-error-color:   #EC663C;
 $background-passed-color:  #78A300;
-$background-started-color: #E7D100;
 
 $title-color:       rgba(255, 255, 255, 0.7);
 $label-color:       rgba(255, 255, 255, 0.7);
@@ -75,16 +74,12 @@ $moreinfo-color:    rgba(255, 255, 255, 0.7);
     color: $moreinfo-color;
   }
 
-  &.failed,
-  &.errored {
+  &.FAILURE,
+  &.ERROR {
     background-color: $background-error-color;
   }
 
-  &.started {
-    background-color: $background-started-color;
-  }
-
-  &.passed {
+  &.SUCCESS {
     background-color: $background-passed-color;
   }
 


### PR DESCRIPTION
Another change to the API, this time the status messages are SUCCESS/FAILURE/ERROR as per https://confluence.jetbrains.com/display/TCD9/REST+API#RESTAPI-BuildLocator